### PR TITLE
Fix CI: Windows glob compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm test
-      - run: node install/verify.mjs
+      - name: Run tests
+        shell: bash
+        run: npm test
+      - name: Smoke test
+        shell: bash
+        run: node install/verify.mjs

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "test": "node --test tests/test-*.mjs",
+    "test": "node --test tests/test-cycle1.mjs tests/test-cycle2.mjs tests/test-cycle4.mjs tests/test-audit.mjs tests/test-config.mjs tests/test-e2e.mjs tests/test-edge-cases.mjs tests/test-enhanced-prompt.mjs tests/test-llm-advisor.mjs",
     "test:cycle1": "node --test tests/test-cycle1.mjs",
     "test:cycle2": "node --test tests/test-cycle2.mjs",
     "test:audit": "node --test tests/test-audit.mjs",


### PR DESCRIPTION
## Summary
- Fix Windows CI failure: PowerShell doesn't expand `node --test tests/test-*.mjs` glob
- List all 9 test files explicitly in `package.json` and use `shell: bash` in CI workflow

## Root Cause
Windows PowerShell passes `tests/test-*.mjs` as a literal string to Node.js instead of expanding it. This caused all 3 Windows CI jobs to fail.

## Test plan
- [ ] All 9 CI jobs pass (ubuntu/macos/windows x node 18/20/22)
- [ ] `npm test` works locally on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CI workflow with explicitly named test execution steps including verification checks
  * Restructured test configuration with explicit test file ordering and new dedicated test commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->