### PR TITLE
feat: add no-console-log rule

### DIFF
--- a/scripts/lib/rules-engine.mjs
+++ b/scripts/lib/rules-engine.mjs
@@ -60,6 +60,14 @@ const CYCLE1_RULES = [
     appliesTo: 'file-write',
     fileExtensions: ['.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs'],
     message: 'Code throws a "not implemented" error. Implement the actual functionality.'
+  },
+  {
+    id: 'no-console-log',
+    description: 'Block console.log() in production code (console.error/warn/info are allowed)',
+    pattern: /\bconsole\.log\s*\(/,
+    appliesTo: 'file-write',
+    fileExtensions: ['.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs'],
+    message: 'Code contains console.log() which should not be in production code. Use a proper logger or console.error/warn for important messages.'
   }
 ];
 

--- a/tests/test-cycle1.mjs
+++ b/tests/test-cycle1.mjs
@@ -98,6 +98,38 @@ describe('Cycle 1 — Code Quality Rules', () => {
     });
   });
 
+  describe('no-console-log', () => {
+    it('should block console.log() in JavaScript', () => {
+      const violations = runCycle1('console.log("debug message")', '.js', 'file-write');
+      assert.ok(violations.some(v => v.ruleId === 'no-console-log'));
+    });
+
+    it('should block console.log() in TypeScript', () => {
+      const violations = runCycle1('console.log(data)', '.ts', 'file-write');
+      assert.ok(violations.some(v => v.ruleId === 'no-console-log'));
+    });
+
+    it('should allow console.error()', () => {
+      const violations = runCycle1('console.error("error message")', '.js', 'file-write');
+      assert.ok(!violations.some(v => v.ruleId === 'no-console-log'));
+    });
+
+    it('should allow console.warn()', () => {
+      const violations = runCycle1('console.warn("warning")', '.js', 'file-write');
+      assert.ok(!violations.some(v => v.ruleId === 'no-console-log'));
+    });
+
+    it('should allow console.info()', () => {
+      const violations = runCycle1('console.info("info")', '.ts', 'file-write');
+      assert.ok(!violations.some(v => v.ruleId === 'no-console-log'));
+    });
+
+    it('should not trigger for Python files', () => {
+      const violations = runCycle1('console.log("test")', '.py', 'file-write');
+      assert.ok(!violations.some(v => v.ruleId === 'no-console-log'));
+    });
+  });
+
   describe('context filtering', () => {
     it('should not run file-write rules in bash context', () => {
       const violations = runCycle1('TODO: fix this', '.sh', 'bash');


### PR DESCRIPTION
Closes #8

## Summary
Adds a new `no-console-log` rule to the Cycle 1 code quality rules that blocks `console.log()` statements in JavaScript/TypeScript production code.

## Changes
- Added `no-console-log` rule to `CYCLE1_RULES` in `scripts/lib/rules-engine.mjs`
- Pattern: `/\bconsole\.log\s*\(/`
- Applies to: `.js`, `.ts`, `.jsx`, `.tsx`, `.mjs`, `.cjs` files
- Added comprehensive tests in `tests/test-cycle1.mjs`

## Behavior
- **Blocked**: `console.log()` calls
- **Allowed**: `console.error()`, `console.warn()`, `console.info()` (for legitimate logging needs)

## Testing
All tests pass including the 6 new tests for this rule:
- Should block console.log() in JavaScript
- Should block console.log() in TypeScript
- Should allow console.error()
- Should allow console.warn()
- Should allow console.info()
- Should not trigger for Python files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a code quality rule that prevents console.log statements in JavaScript and TypeScript files, while permitting console.error, console.warn, and console.info.

* **Tests**
  * Added test coverage for the new console logging rule across multiple file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->