### PR TITLE
Add no-alert rule for browser JS (alert/confirm/prompt)

### DIFF
--- a/scripts/lib/rules-engine.mjs
+++ b/scripts/lib/rules-engine.mjs
@@ -86,6 +86,14 @@ const CYCLE1_RULES = [
     message: 'Code contains a Python debug statement (pdb.set_trace or breakpoint). Remove debug statements before committing.'
   },
   {
+    id: 'no-alert',
+    description: 'Block alert/confirm/prompt usage in browser JS',
+    pattern: /\b(alert|confirm|prompt)\s*\(/,
+    appliesTo: 'file-write',
+    fileExtensions: ['.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs'],
+    message: 'Code uses alert/confirm/prompt. Avoid browser dialogs in production code.'
+  },
+  {
     id: 'no-debugger-rb',
     description: 'Block binding.pry debug statements in Ruby',
     pattern: /\bbinding\.pry\b/,

--- a/tests/test-cycle1.mjs
+++ b/tests/test-cycle1.mjs
@@ -176,6 +176,28 @@ describe('Cycle 1 — Code Quality Rules', () => {
     });
   });
 
+  describe('no-alert', () => {
+    it('should block alert() in JavaScript', () => {
+      const violations = runCycle1('alert("test");', '.js', 'file-write');
+      assert.ok(violations.some(v => v.ruleId === 'no-alert'));
+    });
+
+    it('should block confirm() in JavaScript', () => {
+      const violations = runCycle1('confirm("Are you sure?");', '.js', 'file-write');
+      assert.ok(violations.some(v => v.ruleId === 'no-alert'));
+    });
+
+    it('should block prompt() in JavaScript', () => {
+      const violations = runCycle1('prompt("Enter name");', '.js', 'file-write');
+      assert.ok(violations.some(v => v.ruleId === 'no-alert'));
+    });
+
+    it('should not trigger for non-JavaScript files', () => {
+      const violations = runCycle1('alert("test")', '.py', 'file-write');
+      assert.ok(!violations.some(v => v.ruleId === 'no-alert'));
+    });
+  });
+
   describe('context filtering', () => {
     it('should not run file-write rules in bash context', () => {
       const violations = runCycle1('TODO: fix this', '.sh', 'bash');


### PR DESCRIPTION
This PR adds a new rule `no-alert` to block usage of `alert`, `confirm`, and `prompt` in browser JavaScript files.

**Rule details:**
- Pattern: /\b(alert|confirm|prompt)\s*\(/
- Applies to: file-write
- File extensions: .js, .ts, .jsx, .tsx, .mjs, .cjs
- Message: "Code uses alert/confirm/prompt. Avoid browser dialogs in production code."

Tests are included.

收款地址：ERC20: 0xB3ff5422f49324FD99a0AB7905440C9586d99999 / TRC20: TGPZ5ozM1LLxXyErA45hKfcuR2cF7ntcsk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new linting rule that detects usage of browser dialogs (alert, confirm, prompt) in JavaScript, TypeScript, JSX, TSX, and Node.js module files.

* **Tests**
  * Added test coverage validating that the new rule correctly identifies violations in supported file types and properly excludes non-applicable files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->